### PR TITLE
Swap royalty fees precedence and update providerExtractor

### DIFF
--- a/contracts/interfaces/IRoyaltiesProviderExternal.sol
+++ b/contracts/interfaces/IRoyaltiesProviderExternal.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+import "../lib/LibPart.sol";
+
+interface IRoyaltiesProviderExternal {
+    function getRoyalties(address token, uint tokenId) external returns (LibPart.Part[] memory);
+}

--- a/contracts/royalties/RoyaltiesRegistry.sol
+++ b/contracts/royalties/RoyaltiesRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.11;
 
 import "../interfaces/IRoyaltiesProvider.sol";
+import "../interfaces/IRoyaltiesProviderExternal.sol";
 import "./HasSecondarySaleFees.sol";
 import "./ERC2981Royalties.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
@@ -151,8 +152,8 @@ contract RoyaltiesRegistry is IRoyaltiesProvider, OwnableUpgradeable {
         result = false;
         address providerAddress = royaltiesProviders[token];
         if (providerAddress != address(0x0)) {
-            IRoyaltiesProvider provider = IRoyaltiesProvider(providerAddress);
-            try provider.getRoyalties(token, tokenId) returns (LibPart.Part[] memory royaltiesByProvider, LibPart.Part[] memory collectionFees) {
+            IRoyaltiesProviderExternal provider = IRoyaltiesProviderExternal(providerAddress);
+            try provider.getRoyalties(token, tokenId) returns (LibPart.Part[] memory royaltiesByProvider) {
                 royalties = royaltiesByProvider;
                 result = true;
             } catch {}

--- a/contracts/transfer-manager/UniverseTransferManager.sol
+++ b/contracts/transfer-manager/UniverseTransferManager.sol
@@ -177,8 +177,8 @@ abstract contract UniverseTransferManager is OwnableUpgradeable, ITransferManage
             (address token, uint tokenId) = abi.decode(matchNft.data, (address, uint));
             (LibPart.Part[] memory fees, LibPart.Part[] memory collectionRoyalties) = royaltiesRegistry.getRoyalties(token, tokenId);
 
-            uint256 collectionFees = transferFees(matchCalculate, collectionRoyalties, amount, from, transferDirection);
-            uint256 nftFees = transferFees(matchCalculate, fees, amount - collectionFees, from, transferDirection);
+            uint256 nftFees = transferFees(matchCalculate, fees, amount, from, transferDirection);
+            uint256 collectionFees = transferFees(matchCalculate, collectionRoyalties, amount - nftFees, from, transferDirection);
             totalAmount = collectionFees + nftFees;
         } else if (matchNft.assetClass == LibERC1155LazyMint.ERC1155_LAZY_ASSET_CLASS) {
             (address token, LibERC1155LazyMint.Mint1155Data memory data) = abi.decode(matchNft.data, (address, LibERC1155LazyMint.Mint1155Data));
@@ -209,8 +209,8 @@ abstract contract UniverseTransferManager is OwnableUpgradeable, ITransferManage
         address from,
         bytes4 transferDirection
     ) internal returns (uint256 totalRoyaltiesFee) {
-        uint256 collectionFees = transferFees(matchCalculate, collectionRoyalties, amount.div(matchNftValue), from, transferDirection);
-        uint256 nftFees = transferFees(matchCalculate, nftRoyalties, amount.div(matchNftValue).sub(collectionFees), from, transferDirection);
+        uint256 nftFees = transferFees(matchCalculate, nftRoyalties, amount.div(matchNftValue), from, transferDirection);
+        uint256 collectionFees = transferFees(matchCalculate, collectionRoyalties, amount.div(matchNftValue).sub(nftFees), from, transferDirection);
         return totalRoyaltiesFee = collectionFees.add(nftFees);
     }
 


### PR DESCRIPTION
- Switch precedence of royalties calculation to calculate nftRoyalties first
- Update provider extractor to work with the interface which is compatible with Rarible's Royalty registry